### PR TITLE
Trigger warning when circular references detected in data

### DIFF
--- a/mustache_data.cpp
+++ b/mustache_data.cpp
@@ -159,6 +159,13 @@ static zend_always_inline void mustache_data_from_array_zval(mustache::Data * no
   node->type = mustache::Data::TypeNone;
 
   data_hash = HASH_OF(current);
+
+  if( ++data_hash->nApplyCount > 1 ) {
+    php_error(E_WARNING, "Data includes circular reference");
+    data_hash->nApplyCount--;
+    return;
+  }
+
   data_count = zend_hash_num_elements(data_hash);
   zend_hash_internal_pointer_reset_ex(data_hash, &data_pointer);
   while( zend_hash_get_current_data_ex(data_hash, (void**) &data_entry, &data_pointer) == SUCCESS ) {
@@ -198,6 +205,8 @@ static zend_always_inline void mustache_data_from_array_zval(mustache::Data * no
     }
     zend_hash_move_forward_ex(data_hash, &data_pointer);
   }
+
+  data_hash->nApplyCount--;
 }
 #else
 static zend_always_inline void mustache_data_from_array_zval(mustache::Data * node, zval * current TSRMLS_DC)
@@ -216,6 +225,13 @@ static zend_always_inline void mustache_data_from_array_zval(mustache::Data * no
   node->type = mustache::Data::TypeNone;
 
   data_hash = HASH_OF(current);
+
+  if( ++data_hash->u.v.nApplyCount > 1 ) {
+    php_error(E_WARNING, "Data includes circular reference");
+    data_hash->u.v.nApplyCount--;
+    return;
+  }
+
   data_count = zend_hash_num_elements(data_hash);
   ZEND_HASH_FOREACH_KEY_VAL(data_hash, key_nindex, key, data_entry) {
     if( !key ) {
@@ -250,6 +266,8 @@ static zend_always_inline void mustache_data_from_array_zval(mustache::Data * no
       // Whoops
     }
   } ZEND_HASH_FOREACH_END();
+
+  data_hash->u.v.nApplyCount--;
 }
 #endif
 /* }}} mustache_data_from_array_zval */
@@ -285,6 +303,12 @@ static zend_always_inline void mustache_data_from_object_zval(mustache::Data * n
       data_count = zend_hash_num_elements(data_hash);
     }
     if( data_hash != NULL ) {
+      if( ++data_hash->nApplyCount > 1 ) {
+        php_error(E_WARNING, "Data includes circular reference");
+        data_hash->nApplyCount--;
+        return;
+      }
+
       char *prop_name, *class_name;
       node->type = mustache::Data::TypeMap;
       zend_hash_internal_pointer_reset_ex(data_hash, &data_pointer);
@@ -303,6 +327,8 @@ static zend_always_inline void mustache_data_from_object_zval(mustache::Data * n
         }
         zend_hash_move_forward_ex(data_hash, &data_pointer);
       }
+
+      data_hash->nApplyCount--;
     }
   }
 }
@@ -323,6 +349,13 @@ static zend_always_inline void mustache_data_from_object_zval(mustache::Data * n
   node->type = mustache::Data::TypeNone;
 
   data_hash = Z_OBJ_HT_P(current)->get_properties(current TSRMLS_CC);
+
+  if( ++data_hash->u.v.nApplyCount > 1 ) {
+    php_error(E_WARNING, "Data includes circular reference");
+    data_hash->u.v.nApplyCount--;
+    return;
+  }
+
   data_count = zend_hash_num_elements(data_hash);
   ZEND_HASH_FOREACH_KEY_VAL(data_hash, key_nindex, key, data_entry) {
     if( !key ) {
@@ -357,6 +390,8 @@ static zend_always_inline void mustache_data_from_object_zval(mustache::Data * n
       // Whoops
     }
   } ZEND_HASH_FOREACH_END();
+
+  data_hash->u.v.nApplyCount--;
 }
 #endif
 /* }}} mustache_data_from_object_zval */

--- a/tests/Mustache__render-recursive-array.phpt
+++ b/tests/Mustache__render-recursive-array.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Mustache::render() member function - will not crash if data contains array with circular reference
+--SKIPIF--
+<?php
+
+// references are a distinct type of zval in PHP7 and they are not supported by this extension
+if(!extension_loaded('mustache') || (defined('PHP_VERSION_ID') && PHP_VERSION_ID >= 70000)) die('skip ');
+ ?>
+--FILE--
+<?php
+$m = new Mustache();
+$data = [];
+$data['var'] = &$data;
+$r = $m->render('{{var}}', $data);
+var_dump($r);
+?>
+--EXPECTF--
+Warning: Data includes circular reference in %s on line 5
+string(0) ""

--- a/tests/Mustache__render-recursive-array.phpt
+++ b/tests/Mustache__render-recursive-array.phpt
@@ -9,7 +9,7 @@ if(!extension_loaded('mustache') || (defined('PHP_VERSION_ID') && PHP_VERSION_ID
 --FILE--
 <?php
 $m = new Mustache();
-$data = [];
+$data = array();
 $data['var'] = &$data;
 $r = $m->render('{{var}}', $data);
 var_dump($r);

--- a/tests/Mustache__render-recursive-object.phpt
+++ b/tests/Mustache__render-recursive-object.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Mustache::render() member function - will not crash if data has circular reference
+--SKIPIF--
+<?php
+
+if(!extension_loaded('mustache')) die('skip ');
+ ?>
+--FILE--
+<?php
+$m = new Mustache();
+$data = new stdClass;
+$data->var = $data;
+$r = $m->render('{{var}}', $data);
+var_dump($r);
+?>
+--EXPECTF--
+Warning: Data includes circular reference in %s on line 5
+string(0) ""


### PR DESCRIPTION
Increment nApplyCount on hashes when building mustache::Data. This prevents stack overflows when encountering circular references.