### PR TITLE
Avoid mutating data while rendering

### DIFF
--- a/mustache_data.cpp
+++ b/mustache_data.cpp
@@ -254,6 +254,21 @@ static zend_always_inline void mustache_data_from_array_zval(mustache::Data * no
 #endif
 /* }}} mustache_data_from_array_zval */
 
+/* {{{ mustache_data_from_double_zval */
+static zend_always_inline void mustache_data_from_double_zval(mustache::Data * node, zval * current TSRMLS_DC)
+{
+  char * double_as_string;
+
+  TSRMLS_FETCH();
+  spprintf(&double_as_string, 0, "%.*G", (int) EG(precision), Z_DVAL_P(current));
+
+  node->type = mustache::Data::TypeString;
+  node->val = new std::string(double_as_string);
+
+  efree(double_as_string);
+}
+/* }}} */
+
 /* {{{ mustache_data_from_object_zval */
 #if PHP_MAJOR_VERSION < 7
 static zend_always_inline void mustache_data_from_object_zval(mustache::Data * node, zval * current TSRMLS_DC)
@@ -399,15 +414,7 @@ void mustache_data_from_zval(mustache::Data * node, zval * current TSRMLS_DC)
           break;
 #endif
       case IS_DOUBLE:
-          char * double_as_string;
-
-          TSRMLS_FETCH();
-          spprintf(&double_as_string, 0, "%.*G", (int) EG(precision), Z_DVAL_P(current));
-
-          node->type = mustache::Data::TypeString;
-          node->val = new std::string(double_as_string);
-
-          efree(double_as_string);
+          mustache_data_from_double_zval(node, current TSRMLS_CC);
           break;
       case IS_STRING:
           node->type = mustache::Data::TypeString;

--- a/mustache_data.cpp
+++ b/mustache_data.cpp
@@ -371,44 +371,44 @@ void mustache_data_from_zval(mustache::Data * node, zval * current TSRMLS_DC)
 #endif
   switch( Z_TYPE_P(current) ) {
       case IS_NULL:
-        node->type = mustache::Data::TypeString;
-        node->val = new std::string();
-        break;
+          node->type = mustache::Data::TypeString;
+          node->val = new std::string();
+          break;
       case IS_LONG:
-        node->type = mustache::Data::TypeString;
-        node->val = new std::string(std::to_string(Z_LVAL_P(current)).c_str());
-        break;
+          node->type = mustache::Data::TypeString;
+          node->val = new std::string(std::to_string(Z_LVAL_P(current)).c_str());
+          break;
 #if PHP_MAJOR_VERSION < 7
       case IS_BOOL:
-        node->type = mustache::Data::TypeString;
+          node->type = mustache::Data::TypeString;
 
-        if( Z_LVAL_P(current) ) {
-          node->val = new std::string("1");
-        } else {
-          node->val = new std::string();
-        }
-        break;
+          if( Z_LVAL_P(current) ) {
+            node->val = new std::string("1");
+          } else {
+            node->val = new std::string();
+          }
+          break;
 #else
       case IS_TRUE:
-        node->type = mustache::Data::TypeString;
-        node->val = new std::string("1");
-        break;
+          node->type = mustache::Data::TypeString;
+          node->val = new std::string("1");
+          break;
       case IS_FALSE:
-        node->type = mustache::Data::TypeString;
-        node->val = new std::string();
-        break;
+          node->type = mustache::Data::TypeString;
+          node->val = new std::string();
+          break;
 #endif
       case IS_DOUBLE:
-        char * double_as_string;
+          char * double_as_string;
 
-        TSRMLS_FETCH();
-        spprintf(&double_as_string, 0, "%.*G", (int) EG(precision), Z_DVAL_P(current));
+          TSRMLS_FETCH();
+          spprintf(&double_as_string, 0, "%.*G", (int) EG(precision), Z_DVAL_P(current));
 
-        node->type = mustache::Data::TypeString;
-        node->val = new std::string(double_as_string);
+          node->type = mustache::Data::TypeString;
+          node->val = new std::string(double_as_string);
 
-        efree(double_as_string);
-        break;
+          efree(double_as_string);
+          break;
       case IS_STRING:
           node->type = mustache::Data::TypeString;
           node->val = new std::string(Z_STRVAL_P(current)/*, (size_t) Z_STRLEN_P(current)*/);

--- a/mustache_data.cpp
+++ b/mustache_data.cpp
@@ -259,7 +259,6 @@ static zend_always_inline void mustache_data_from_double_zval(mustache::Data * n
 {
   char * double_as_string;
 
-  TSRMLS_FETCH();
   spprintf(&double_as_string, 0, "%.*G", (int) EG(precision), Z_DVAL_P(current));
 
   node->type = mustache::Data::TypeString;

--- a/mustache_data.cpp
+++ b/mustache_data.cpp
@@ -390,7 +390,7 @@ void mustache_data_from_zval(mustache::Data * node, zval * current TSRMLS_DC)
           break;
       case IS_LONG:
           node->type = mustache::Data::TypeString;
-          node->val = new std::string(std::to_string(Z_LVAL_P(current)).c_str());
+          node->val = new std::string(std::to_string(Z_LVAL_P(current)));
           break;
 #if PHP_MAJOR_VERSION < 7
       case IS_BOOL:

--- a/mustache_data.cpp
+++ b/mustache_data.cpp
@@ -371,16 +371,45 @@ void mustache_data_from_zval(mustache::Data * node, zval * current TSRMLS_DC)
 #endif
   switch( Z_TYPE_P(current) ) {
       case IS_NULL:
+        node->type = mustache::Data::TypeString;
+        node->val = new std::string();
+        break;
       case IS_LONG:
+        node->type = mustache::Data::TypeString;
+        node->val = new std::string(std::to_string(Z_LVAL_P(current)).c_str());
+        break;
 #if PHP_MAJOR_VERSION < 7
       case IS_BOOL:
+        node->type = mustache::Data::TypeString;
+
+        if( Z_LVAL_P(current) ) {
+          node->val = new std::string("1");
+        } else {
+          node->val = new std::string();
+        }
+        break;
 #else
       case IS_TRUE:
+        node->type = mustache::Data::TypeString;
+        node->val = new std::string("1");
+        break;
       case IS_FALSE:
+        node->type = mustache::Data::TypeString;
+        node->val = new std::string();
+        break;
 #endif
       case IS_DOUBLE:
+        char * double_as_string;
+
+        TSRMLS_FETCH();
+        spprintf(&double_as_string, 0, "%.*G", (int) EG(precision), Z_DVAL_P(current));
+
+        node->type = mustache::Data::TypeString;
+        node->val = new std::string(double_as_string);
+
+        efree(double_as_string);
+        break;
       case IS_STRING:
-          convert_to_string(current);
           node->type = mustache::Data::TypeString;
           node->val = new std::string(Z_STRVAL_P(current)/*, (size_t) Z_STRLEN_P(current)*/);
           break;

--- a/tests/Mustache__render-does-not-mutate-double.phpt
+++ b/tests/Mustache__render-does-not-mutate-double.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Mustache::render() member function - Will not mutate double
+--SKIPIF--
+<?php
+
+if(!extension_loaded('mustache')) die('skip ');
+ ?>
+--FILE--
+<?php
+$m = new Mustache();
+$data = new stdClass;
+$data->var = 1.2345;
+$r = $m->render('{{var}}', $data);
+var_dump($r);
+var_dump(strval(1.2345)); // verify rendered template matches strval() output
+var_dump($data->var);
+?>
+--EXPECT--
+string(6) "1.2345"
+string(6) "1.2345"
+float(1.2345)

--- a/tests/Mustache__render-does-not-mutate-false.phpt
+++ b/tests/Mustache__render-does-not-mutate-false.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Mustache::render() member function - Will not mutate false
+--SKIPIF--
+<?php
+
+if(!extension_loaded('mustache')) die('skip ');
+ ?>
+--FILE--
+<?php
+$m = new Mustache();
+$data = new stdClass;
+$data->var = false;
+$r = $m->render('{{var}}', $data);
+var_dump($r);
+var_dump(strval(false)); // verify rendered template matches strval() output
+var_dump($data->var);
+?>
+--EXPECT--
+string(0) ""
+string(0) ""
+bool(false)

--- a/tests/Mustache__render-does-not-mutate-int.phpt
+++ b/tests/Mustache__render-does-not-mutate-int.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Mustache::render() member function - Will not mutate int
+--SKIPIF--
+<?php
+
+if(!extension_loaded('mustache')) die('skip ');
+ ?>
+--FILE--
+<?php
+$m = new Mustache();
+$data = new stdClass;
+$data->var = 1;
+$r = $m->render('{{var}}', $data);
+var_dump($r);
+var_dump(strval(1)); // verify rendered template matches strval() output
+var_dump($data->var);
+?>
+--EXPECT--
+string(1) "1"
+string(1) "1"
+int(1)

--- a/tests/Mustache__render-does-not-mutate-null.phpt
+++ b/tests/Mustache__render-does-not-mutate-null.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Mustache::render() member function - Will not mutate null
+--SKIPIF--
+<?php
+
+if(!extension_loaded('mustache')) die('skip ');
+ ?>
+--FILE--
+<?php
+$m = new Mustache();
+$data = new stdClass;
+$data->var = null;
+$r = $m->render('{{var}}', $data);
+var_dump($r);
+var_dump(strval(null)); // verify rendered template matches strval() output
+var_dump($data->var);
+?>
+--EXPECT--
+string(0) ""
+string(0) ""
+NULL

--- a/tests/Mustache__render-does-not-mutate-true.phpt
+++ b/tests/Mustache__render-does-not-mutate-true.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Mustache::render() member function - Will not mutate true
+--SKIPIF--
+<?php
+
+if(!extension_loaded('mustache')) die('skip ');
+ ?>
+--FILE--
+<?php
+$m = new Mustache();
+$data = new stdClass;
+$data->var = true;
+$r = $m->render('{{var}}', $data);
+var_dump($r);
+var_dump(strval(true)); // verify rendered template matches strval() output
+var_dump($data->var);
+?>
+--EXPECT--
+string(1) "1"
+string(1) "1"
+bool(true)


### PR DESCRIPTION
mustache_data_from_zval() currently converts zvals to strings. This can cause unintended side effects if values are used later in other contexts.