### PR TITLE
Remove unused variables

### DIFF
--- a/mustache_data.cpp
+++ b/mustache_data.cpp
@@ -675,7 +675,6 @@ PHP_METHOD(MustacheData, __construct)
 
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_MustacheData * payload = php_mustache_data_object_fetch_object(_this_zval TSRMLS_CC);
     
     // Check if argument was given
@@ -705,7 +704,6 @@ PHP_METHOD(MustacheData, toValue)
     }
 
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_MustacheData * payload = php_mustache_data_object_fetch_object(_this_zval TSRMLS_CC);
   
     // Check if data was initialized

--- a/mustache_mustache.cpp
+++ b/mustache_mustache.cpp
@@ -139,7 +139,6 @@ static zend_object_value Mustache_obj_create(zend_class_entry *class_type TSRMLS
   
   try {
     struct php_obj_Mustache * payload = NULL;
-    zval * tmp = NULL;
 
     payload = (struct php_obj_Mustache *) emalloc(sizeof(php_obj_Mustache));
     memset(payload, 0, sizeof(php_obj_Mustache));
@@ -696,7 +695,6 @@ PHP_METHOD(Mustache, parse)
 
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_Mustache * payload = php_mustache_mustache_object_fetch_object(_this_zval TSRMLS_CC);
     
     // Check template parameter


### PR DESCRIPTION
The NULL will presumably optimize out, but Z_OBJCE_P() does a little lifting to get its return value.