### PR TITLE
Handle zvals with type IS_REFERENCE

### DIFF
--- a/mustache_data.cpp
+++ b/mustache_data.cpp
@@ -560,8 +560,13 @@ static zend_always_inline void mustache_data_from_object_zval(mustache::Data * n
 void mustache_data_from_zval(mustache::Data * node, zval * current TSRMLS_DC)
 {
 #if PHP_MAJOR_VERSION >= 7
-  if (Z_TYPE_P(current) == IS_INDIRECT) {
-    current = Z_INDIRECT_P(current);
+  switch( Z_TYPE_P(current) ) {
+    case IS_INDIRECT:
+      current = Z_INDIRECT_P(current);
+      break;
+    case IS_REFERENCE:
+      current = Z_REFVAL_P(current);
+      break;
   }
 #endif
   switch( Z_TYPE_P(current) ) {

--- a/tests/Mustache__render-references.phpt
+++ b/tests/Mustache__render-references.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Mustache::render() member function - references
+--SKIPIF--
+<?php
+
+if(!extension_loaded('mustache')) die('skip ');
+ ?>
+--FILE--
+<?php
+$value = 'val';
+
+$m = new Mustache();
+$r = $m->render('{{var}}', array(
+  'var' => &$value,
+));
+var_dump($r);
+
+?>
+--EXPECT--
+string(3) "val"


### PR DESCRIPTION
This is a new "type" in PHP7 which can be handled similarly to IS_INDIRECT. There's some discussion of these changes here:
https://nikic.github.io/2015/05/05/Internal-value-representation-in-PHP-7-part-1.html