### PR TITLE
Handle lambdas in lists

### DIFF
--- a/mustache_data.cpp
+++ b/mustache_data.cpp
@@ -185,7 +185,7 @@ static zend_always_inline void mustache_data_from_array_zval(mustache::Data * no
   ulong key_nindex = 0;
   std::string ckey;
   
-  int ArrayPos = 0;
+  int length = 0;
   mustache::Data * child = NULL;
 
   node->type = mustache::Data::TypeNone;
@@ -224,8 +224,8 @@ static zend_always_inline void mustache_data_from_array_zval(mustache::Data * no
     if( node->type == mustache::Data::TypeArray ) {
       child = new mustache::Data();
       mustache_data_from_zval(child, *data_entry TSRMLS_CC);
-      node->array[ArrayPos++] = child;
-      node->length = ArrayPos;
+      node->array.push_back(child);
+      node->length = ++length;
     } else if( node->type == mustache::Data::TypeMap ) {
       child = new mustache::Data;
       mustache_data_from_zval(child, *data_entry TSRMLS_CC);
@@ -250,7 +250,7 @@ static zend_always_inline void mustache_data_from_array_zval(mustache::Data * no
   std::string ckey;
   zval * data_entry = NULL;
   
-  int ArrayPos = 0;
+  int length = 0;
   mustache::Data * child = NULL;
   zend_class_entry * ce = NULL;
 
@@ -286,8 +286,8 @@ static zend_always_inline void mustache_data_from_array_zval(mustache::Data * no
     if( node->type == mustache::Data::TypeArray ) {
   	  child = new mustache::Data();
       mustache_data_from_zval(child, data_entry TSRMLS_CC);
-      node->array[ArrayPos++] = child;
-      node->length = ArrayPos;
+      node->array.push_back(child);
+      node->length = ++length;
     } else if( node->type == mustache::Data::TypeMap ) {
       child = new mustache::Data;
       mustache_data_from_zval(child, data_entry TSRMLS_CC);

--- a/tests/Mustache__render-lambda-invokable-array.phpt
+++ b/tests/Mustache__render-lambda-invokable-array.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Mustache::render() member function - will render a list of lambdas, provided as invokables, as variables
+--SKIPIF--
+<?php
+
+if(!extension_loaded('mustache')) die('skip ');
+ ?>
+--FILE--
+<?php
+class Invokable {
+  private $value;
+  public function __construct($value) { $this->value = $value; }
+  public function __invoke() { return $this->value; }
+}
+
+$m = new Mustache();
+$data = array('list' => array(new Invokable(1), new Invokable(2), new Invokable(3)));
+$r = $m->render('{{#list}}{{.}}{{/list}}', $data);
+var_dump($r);
+?>
+--EXPECT--
+string(3) "123"


### PR DESCRIPTION
The added unit test verifies my recent changes to libmustache. The changes to mustache_data_from_array_zval were needed for a less than clear reason. It seemed that when array indices were set explicitly, it didn't end up having any contents visible to the Data destructor, so the associated memory wouldn't be freed. I might want to go back at some point and get rid of the length attribute of Data. It looks like it's mainly used for initialization, so only serves to be something that has to be kept in sync.