### PR TITLE
Handle zvals that are indirect references

### DIFF
--- a/mustache_data.cpp
+++ b/mustache_data.cpp
@@ -560,14 +560,10 @@ static zend_always_inline void mustache_data_from_object_zval(mustache::Data * n
 void mustache_data_from_zval(mustache::Data * node, zval * current TSRMLS_DC)
 {
 #if PHP_MAJOR_VERSION >= 7
-  switch( Z_TYPE_P(current) ) {
-    case IS_INDIRECT:
-      current = Z_INDIRECT_P(current);
-      break;
-    case IS_REFERENCE:
-      current = Z_REFVAL_P(current);
-      break;
+  if( Z_TYPE_P(current) == IS_INDIRECT ) {
+    current = Z_INDIRECT_P(current);
   }
+  ZVAL_DEREF(current);
 #endif
   switch( Z_TYPE_P(current) ) {
       case IS_NULL:


### PR DESCRIPTION
I don't have a great way to translate this into a test case. My main [resource](https://nikic.github.io/2015/05/05/Internal-value-representation-in-PHP-7-part-1.html) on types in PHP7 basically says that "indirect" is an "internal use only" thing. I'd only note that I searched php-src for references to IS_INDIRECT and found this to be a recurring pattern.