### PR TITLE
Use macro that will automatically get value of indirect zvals

### DIFF
--- a/mustache_data.cpp
+++ b/mustache_data.cpp
@@ -265,7 +265,7 @@ static zend_always_inline void mustache_data_from_array_zval(mustache::Data * no
   }
 
   data_count = zend_hash_num_elements(data_hash);
-  ZEND_HASH_FOREACH_KEY_VAL(data_hash, key_nindex, key, data_entry) {
+  ZEND_HASH_FOREACH_KEY_VAL_IND(data_hash, key_nindex, key, data_entry) {
     if( !key ) {
       if( node->type == mustache::Data::TypeNone ) {
         node->init(mustache::Data::TypeArray, data_count);
@@ -412,7 +412,7 @@ static zend_always_inline void mustache_data_from_object_properties_zval(mustach
       return;
     }
 
-    ZEND_HASH_FOREACH_KEY_VAL(data_hash, key_nindex, key, data_entry) {
+    ZEND_HASH_FOREACH_KEY_VAL_IND(data_hash, key_nindex, key, data_entry) {
       if( key && ZSTR_LEN(key) && ZSTR_VAL(key)[0] ) { // skip private/protected
         prop_name = ZSTR_VAL(key);
 
@@ -511,7 +511,7 @@ static zend_always_inline void mustache_data_from_object_functions_zval(mustache
       return;
     }
 
-    ZEND_HASH_FOREACH_KEY_VAL(data_hash, key_nindex, key, data_entry) {
+    ZEND_HASH_FOREACH_KEY_VAL_IND(data_hash, key_nindex, key, data_entry) {
       function_entry = (zend_function *) Z_PTR_P(data_entry);
       if( is_valid_function(function_entry) ) {
         node->type = mustache::Data::TypeMap;


### PR DESCRIPTION
I ran into a situation where a hash could have a zval that indirectly refers to an zval of type IS_UNDEF. The foreach macro knows to skip undefined zvals, but it won't skip them if it only sees the IS_INDIRECT zval. This macro pulls out the value that matters here. This potentially means that 2b92410bb7743b01e2796529ddc77a2b0eb09607 isn't necessary, but since mustache_data_from_zval() is called in other contexts, it feels safer to leave it in place.