### PR TITLE
Use ZEND_HASH_APPLY_PROTECTION when checking for recursion in PHP7

### DIFF
--- a/mustache_data.cpp
+++ b/mustache_data.cpp
@@ -258,7 +258,7 @@ static zend_always_inline void mustache_data_from_array_zval(mustache::Data * no
 
   data_hash = HASH_OF(current);
 
-  if( ++data_hash->u.v.nApplyCount > 1 ) {
+  if( ZEND_HASH_APPLY_PROTECTION(data_hash) && ++data_hash->u.v.nApplyCount > 1 ) {
     php_error(E_WARNING, "Data includes circular reference");
     data_hash->u.v.nApplyCount--;
     return;
@@ -299,7 +299,9 @@ static zend_always_inline void mustache_data_from_array_zval(mustache::Data * no
     }
   } ZEND_HASH_FOREACH_END();
 
-  data_hash->u.v.nApplyCount--;
+  if( ZEND_HASH_APPLY_PROTECTION(data_hash) ) {
+    data_hash->u.v.nApplyCount--;
+  }
 }
 #endif
 /* }}} mustache_data_from_array_zval */
@@ -406,7 +408,7 @@ static zend_always_inline void mustache_data_from_object_properties_zval(mustach
     data_hash = Z_OBJ_HT_P(current)->get_properties(current TSRMLS_CC);
   }
   if( data_hash != NULL && zend_hash_num_elements(data_hash) > 0 ) {
-    if( ++data_hash->u.v.nApplyCount > 1 ) {
+    if( ZEND_HASH_APPLY_PROTECTION(data_hash) && ++data_hash->u.v.nApplyCount > 1 ) {
       php_error(E_WARNING, "Data includes circular reference");
       data_hash->u.v.nApplyCount--;
       return;
@@ -439,7 +441,9 @@ static zend_always_inline void mustache_data_from_object_properties_zval(mustach
       }
     } ZEND_HASH_FOREACH_END();
 
-    data_hash->u.v.nApplyCount--;
+    if( ZEND_HASH_APPLY_PROTECTION(data_hash) ) {
+      data_hash->u.v.nApplyCount--;
+    }
   }
 }
 #endif
@@ -505,7 +509,7 @@ static zend_always_inline void mustache_data_from_object_functions_zval(mustache
     data_hash = &ce->function_table;
   }
   if( data_hash != NULL && zend_hash_num_elements(data_hash) > 0 ) {
-    if( ++data_hash->u.v.nApplyCount > 1 ) {
+    if( ZEND_HASH_APPLY_PROTECTION(data_hash) && ++data_hash->u.v.nApplyCount > 1 ) {
       php_error(E_WARNING, "Data includes circular reference");
       data_hash->u.v.nApplyCount--;
       return;
@@ -526,7 +530,9 @@ static zend_always_inline void mustache_data_from_object_functions_zval(mustache
       }
     } ZEND_HASH_FOREACH_END();
 
-    data_hash->u.v.nApplyCount--;
+    if( ZEND_HASH_APPLY_PROTECTION(data_hash) ) {
+      data_hash->u.v.nApplyCount--;
+    }
   }
 }
 #endif


### PR DESCRIPTION
PHP7 + OPcache can produce "immutable arrays," which are described here:
https://nikic.github.io/2015/06/19/Internal-value-representation-in-PHP-7-part-2.html#arrays

While I've run into issues that smell of this in testing, I haven't been able to get a reproducible test case. I couldn't think of a way to get one of these arrays in data so it wouldn't be a leaf node, which I think is necessary to get the counter not to decrement back. There's also the issue that you can't totally control what OPcache will do, or whether it's enabled in conjunction with a .phpt test. That said, I'm open to amending if you have a suggestion here. I would certainly feel more comfortable about this being airtight with some before/after testing.

I modeled this change after the print_r() implementation (e.g., zend_print_flat_zval_r() in zend.c).