### PR TITLE
Fix compilation issue on CentOS 6 (Fixes #31)

### DIFF
--- a/mustache_data.cpp
+++ b/mustache_data.cpp
@@ -578,7 +578,7 @@ void mustache_data_from_zval(mustache::Data * node, zval * current TSRMLS_DC)
           break;
       case IS_LONG:
           node->type = mustache::Data::TypeString;
-          node->val = new std::string(std::to_string(Z_LVAL_P(current)));
+          node->val = new std::string(std::to_string((long long)Z_LVAL_P(current)));
           break;
 #if PHP_MAJOR_VERSION < 7
       case IS_BOOL:


### PR DESCRIPTION
* Fix call of overloaded ‘to_string(long int&)’ is ambiguous

Possibly related: https://stackoverflow.com/questions/10664699/stdto-string-more-than-instance-of-overloaded-function-matches-the-argument