### PR TITLE
allow php 7.2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -249,7 +249,7 @@ Initial PECL release
   <required>
    <php>
     <min>5.6.0</min>
-    <max>7.1.99</max>
+    <max>7.2.99</max>
    </php>
    <pearinstaller>
     <min>1.4.1</min>


### PR DESCRIPTION
```
=====================================================================
PHP         : /opt/remi/php72/root/usr/bin/php 
PHP_SAPI    : cli
PHP_VERSION : 7.2.0alpha1
ZEND_VERSION: 3.2.0-dev
PHP_OS      : Linux - Linux builder.remirepo.net 4.11.3-200.fc25.x86_64 #1 SMP Thu May 25 19:03:07 UTC 2017 x86_64
INI actual  : /work/GIT/php-mustache/tmp-php.ini
More .INIs  :   
---------------------------------------------------------------------
PHP         : /opt/remi/php72/root/usr/bin/phpdbg 
PHP_SAPI    : phpdbg
PHP_VERSION : 7.2.0alpha1
ZEND_VERSION: 3.2.0-dev
PHP_OS      : Linux - Linux builder.remirepo.net 4.11.3-200.fc25.x86_64 #1 SMP Thu May 25 19:03:07 UTC 2017 x86_64
INI actual  : /work/GIT/php-mustache/tmp-php.ini
More .INIs  : 
---------------------------------------------------------------------
CWD         : /work/GIT/php-mustache
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
TIME START 2017-06-09 08:07:04
=====================================================================
...
=====================================================================
TIME END 2017-06-09 08:07:07

=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   15
---------------------------------------------------------------------

Number of tests :  190               185
Tests skipped   :    5 (  2.6%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Expected fail   :    0 (  0.0%) (  0.0%)
Tests passed    :  185 ( 97.4%) (100.0%)
---------------------------------------------------------------------
Time taken      :    3 seconds
=====================================================================
```