### PR TITLE
Build warnings

### DIFF
--- a/mustache_ast.cpp
+++ b/mustache_ast.cpp
@@ -216,11 +216,12 @@ static zend_object * MustacheAST_obj_create(zend_class_entry * ce TSRMLS_DC)
     zend_object_std_init(&intern->std, ce TSRMLS_CC);
     intern->std.handlers = &MustacheAST_obj_handlers;
     intern->node = NULL;
+    return &intern->std;
   } catch(...) {
     mustache_exception_handler(TSRMLS_C);
   }
-  
-  return &intern->std;
+
+  return NULL;
 }
 #endif
 /* }}} */
@@ -271,7 +272,6 @@ PHP_METHOD(MustacheAST, __construct)
     
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_MustacheAST * payload = php_mustache_ast_object_fetch_object(_this_zval TSRMLS_CC);
     
     // Check payload
@@ -301,7 +301,6 @@ PHP_METHOD(MustacheAST, __sleep)
     
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_MustacheAST * payload = php_mustache_ast_object_fetch_object(_this_zval TSRMLS_CC);
     
     array_init(return_value);
@@ -339,7 +338,6 @@ PHP_METHOD(MustacheAST, toArray)
     
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_MustacheAST * payload = php_mustache_ast_object_fetch_object(_this_zval TSRMLS_CC);
     
     // Check payload
@@ -369,7 +367,6 @@ PHP_METHOD(MustacheAST, __toString)
     
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_MustacheAST * payload = php_mustache_ast_object_fetch_object(_this_zval TSRMLS_CC);
     
     // Check payload
@@ -397,7 +394,6 @@ PHP_METHOD(MustacheAST, __toString)
 static inline void php_mustache_ast_wakeup(zval * _this_zval, zval * return_value TSRMLS_DC)
 {
     zval rv;
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_MustacheAST * payload = php_mustache_ast_object_fetch_object(_this_zval TSRMLS_CC);
     zval * value = _zend_read_property(Z_OBJCE_P(_this_zval), _this_zval, "binaryString", sizeof("binaryString")-1, 1, &rv);
 

--- a/mustache_class_method_lambda.cpp
+++ b/mustache_class_method_lambda.cpp
@@ -15,7 +15,6 @@ ClassMethodLambda::~ClassMethodLambda()
 int ClassMethodLambda::getUserFunctionParamCount()
 {
   zend_class_entry * ce = Z_OBJCE_P(object);
-  HashTable * function_table = NULL;
   zval * zv = NULL;
   zend_function * function_entry = NULL;
 

--- a/mustache_data.cpp
+++ b/mustache_data.cpp
@@ -109,11 +109,12 @@ static zend_object * MustacheData_obj_create(zend_class_entry * ce TSRMLS_DC)
     intern = (struct php_obj_MustacheData *) ecalloc(1, sizeof(struct php_obj_MustacheData) + zend_object_properties_size(ce));
     zend_object_std_init(&intern->std, ce TSRMLS_CC);
     intern->std.handlers = &MustacheData_obj_handlers;
+    return &intern->std;
   } catch(...) {
     mustache_exception_handler(TSRMLS_C);
   }
-  
-  return &intern->std;
+
+  return NULL;
 }
 #endif
 /* }}} */
@@ -252,7 +253,6 @@ static zend_always_inline void mustache_data_from_array_zval(mustache::Data * no
   
   int length = 0;
   mustache::Data * child = NULL;
-  zend_class_entry * ce = NULL;
 
   node->type = mustache::Data::TypeNone;
 
@@ -266,6 +266,7 @@ static zend_always_inline void mustache_data_from_array_zval(mustache::Data * no
 
   data_count = zend_hash_num_elements(data_hash);
   ZEND_HASH_FOREACH_KEY_VAL_IND(data_hash, key_nindex, key, data_entry) {
+    (void)key_nindex; /* avoid [-Wunused-but-set-variable] */
     if( !key ) {
       if( node->type == mustache::Data::TypeNone ) {
         node->init(mustache::Data::TypeArray, data_count);
@@ -388,7 +389,6 @@ static zend_always_inline void mustache_data_from_object_properties_zval(mustach
 static zend_always_inline void mustache_data_from_object_properties_zval(mustache::Data * node, zval * current TSRMLS_DC)
 {
   HashTable * data_hash = NULL;
-  long data_count = 0;
   ulong key_nindex = 0;
   zend_string * key;
   std::string ckey;
@@ -415,6 +415,7 @@ static zend_always_inline void mustache_data_from_object_properties_zval(mustach
     }
 
     ZEND_HASH_FOREACH_KEY_VAL_IND(data_hash, key_nindex, key, data_entry) {
+      (void)key_nindex; /* avoid [-Wunused-but-set-variable] */
       if( key && ZSTR_LEN(key) && ZSTR_VAL(key)[0] ) { // skip private/protected
         prop_name = ZSTR_VAL(key);
 
@@ -517,6 +518,8 @@ static zend_always_inline void mustache_data_from_object_functions_zval(mustache
 
     ZEND_HASH_FOREACH_KEY_VAL_IND(data_hash, key_nindex, key, data_entry) {
       function_entry = (zend_function *) Z_PTR_P(data_entry);
+      (void)key; /* avoid [-Wunused-but-set-variable] */
+      (void)key_nindex;
       if( is_valid_function(function_entry) ) {
         node->type = mustache::Data::TypeMap;
 

--- a/mustache_lambda_helper.cpp
+++ b/mustache_lambda_helper.cpp
@@ -97,11 +97,11 @@ static zend_object * MustacheLambdaHelper_obj_create(zend_class_entry * ce TSRML
     intern = (struct php_obj_MustacheLambdaHelper *) ecalloc(1, sizeof(struct php_obj_MustacheLambdaHelper) + zend_object_properties_size(ce));
     zend_object_std_init(&intern->std, ce TSRMLS_CC);
     intern->std.handlers = &MustacheLambdaHelper_obj_handlers;
+    return &intern->std;
   } catch(...) {
     mustache_exception_handler(TSRMLS_C);
   }
-
-  return &intern->std;
+  return NULL;
 }
 #endif
 /* }}} */
@@ -149,7 +149,6 @@ PHP_METHOD(MustacheLambdaHelper, render)
 
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_MustacheLambdaHelper * payload = php_mustache_lambda_helper_object_fetch_object(_this_zval TSRMLS_CC);
 
     std::string templateStr(template_str/*, (size_t) Z_STRLEN_P(template_str)*/);

--- a/mustache_mustache.cpp
+++ b/mustache_mustache.cpp
@@ -167,11 +167,12 @@ static zend_object * Mustache_obj_create(zend_class_entry * ce TSRMLS_DC)
     intern->std.handlers = &Mustache_obj_handlers;
 
     intern->mustache = mustache_new_Mustache(TSRMLS_C);
+    return &intern->std;
   } catch(...) {
     mustache_exception_handler(TSRMLS_C);
   }
   
-  return &intern->std;
+  return NULL;
 }
 #endif
 /* }}} */
@@ -321,6 +322,7 @@ bool mustache_parse_partials_param(zval * array, mustache::Mustache * mustache,
         zend_string * key = NULL;
 
         ZEND_HASH_FOREACH_KEY_VAL(data_hash, key_nindex, key, data_entry) {
+            (void)key_nindex;
             if( !key ) {
                 php_error(E_WARNING, "Partial array contains a non-string key");
             } else {
@@ -329,6 +331,7 @@ bool mustache_parse_partials_param(zval * array, mustache::Mustache * mustache,
         } ZEND_HASH_FOREACH_END();
     } while(0);
 #endif
+  return true;
 }
 /* }}} */
 
@@ -405,8 +408,6 @@ PHP_METHOD(Mustache, __construct)
 
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
-    struct php_obj_Mustache * payload = php_mustache_mustache_object_fetch_object(_this_zval TSRMLS_CC);
     
   } catch(...) {
     mustache_exception_handler(TSRMLS_C);
@@ -427,7 +428,6 @@ PHP_METHOD(Mustache, getEscapeByDefault)
 
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_Mustache * payload = php_mustache_mustache_object_fetch_object(_this_zval TSRMLS_CC);
     
     // Main
@@ -456,7 +456,6 @@ PHP_METHOD(Mustache, getStartSequence)
 
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_Mustache * payload = php_mustache_mustache_object_fetch_object(_this_zval TSRMLS_CC);
     
     // Main
@@ -482,7 +481,6 @@ PHP_METHOD(Mustache, getStopSequence)
 
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_Mustache * payload = php_mustache_mustache_object_fetch_object(_this_zval TSRMLS_CC);
     
     // Main
@@ -511,7 +509,6 @@ PHP_METHOD(Mustache, setEscapeByDefault)
 
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_Mustache * payload = php_mustache_mustache_object_fetch_object(_this_zval TSRMLS_CC);
   
     // Main
@@ -541,7 +538,6 @@ PHP_METHOD(Mustache, setStartSequence)
 
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_Mustache * payload = php_mustache_mustache_object_fetch_object(_this_zval TSRMLS_CC);
     
     // Main
@@ -571,7 +567,6 @@ PHP_METHOD(Mustache, setStopSequence)
 
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_Mustache * payload = php_mustache_mustache_object_fetch_object(_this_zval TSRMLS_CC);
     
     // Main
@@ -601,7 +596,6 @@ PHP_METHOD(Mustache, compile)
 
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_Mustache * payload = php_mustache_mustache_object_fetch_object(_this_zval TSRMLS_CC);
     
     // Prepare template tree
@@ -649,7 +643,6 @@ PHP_METHOD(Mustache, execute)
 
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_Mustache * payload = php_mustache_mustache_object_fetch_object(_this_zval TSRMLS_CC);
     
     // Prepare code
@@ -753,7 +746,6 @@ PHP_METHOD(Mustache, render)
 
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_Mustache * payload = php_mustache_mustache_object_fetch_object(_this_zval TSRMLS_CC);
     
     // Prepare template tree
@@ -811,7 +803,6 @@ PHP_METHOD(Mustache, tokenize)
 
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
     struct php_obj_Mustache * payload = php_mustache_mustache_object_fetch_object(_this_zval TSRMLS_CC);
     
     // Assign template to string
@@ -846,8 +837,6 @@ PHP_METHOD(Mustache, debugDataStructure)
 
     // Class parameters
     _this_zval = getThis();
-    zend_class_entry * _this_ce = Z_OBJCE_P(_this_zval);
-    struct php_obj_Mustache * payload = php_mustache_mustache_object_fetch_object(_this_zval TSRMLS_CC);
     
     // Prepare template data
     mustache::Data templateData;

--- a/php_mustache.cpp
+++ b/php_mustache.cpp
@@ -79,7 +79,7 @@ zend_module_entry mustache_module_entry = {
   (char *) PHP_MUSTACHE_NAME,    /* Name */
   NULL,                          /* Functions */
   PHP_MINIT(mustache),           /* MINIT */
-  NULL,                          /* MSHUTDOWN */
+  PHP_MSHUTDOWN(mustache),       /* MSHUTDOWN */
   NULL,                          /* RINIT */
   NULL,                          /* RSHUTDOWN */
   PHP_MINFO(mustache),           /* MINFO */


### PR DESCRIPTION
Too much build warnings introduce noise which can hide serious issues.
This fix all of them, even if some are mostly false-positive from the compiler.
