### PR TITLE
add link to remi's repo for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ All features of Mustache are supported EXCEPT:
 
 #### Linux
 
-For Ubuntu LTS, the extension is available in a [PPA](https://launchpad.net/~jbboehr/+archive/ubuntu/mustache), or via source:
+For **Ubuntu LTS**, the extension is available in a [PPA](https://launchpad.net/~jbboehr/+archive/ubuntu/mustache), or via source:
 
 Install [libmustache](https://github.com/jbboehr/libmustache)
 
@@ -32,6 +32,14 @@ make
 sudo make install
 echo extension=mustache.so | sudo tee /etc/php5/conf.d/mustache.ini
 ```
+
+For **Fedora**, the extension is available in [Remi's repository](https://rpms.remirepo.net/) (change 24 to match your Fedora version)
+
+``` sh
+dnf install https://rpms.remirepo.net/fedora/remi-release-24.rpm
+dnf install --enablerepo=remi php-pecl-mustache
+```
+
 
 #### OSX
 


### PR DESCRIPTION
I usually only propose to add link to official repository when the package is available there.

But as you also have a link to your PPA for Ubuntu, could male sense to add this for Fedora users

I didn't add information for RHEL/CentOS (also available), as it is not available for default PHP version (5.4).
