### PR TITLE
fix for PHP 7.3 and Array/Object recursion protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ config.status
 config.sub
 configure
 configure.in
+configure.ac
 install-sh
 libtool
 ltmain.sh


### PR DESCRIPTION
From UPGRADING.INTERNALS

```
  c. Protection from recursion during processing circular data structures was
     refactored. HashTable.nApplyCount and IS_OBJ_APPLY_COUNT are replaced by
     single flag GC_PROTECTED. Corresponding macros Z_OBJ_APPLY_COUNT,
     Z_OBJ_INC_APPLY_COUNT, Z_OBJ_DEC_APPLY_COUNT, ZEND_HASH_GET_APPLY_COUNT,
     ZEND_HASH_INC_APPLY_COUNT, ZEND_HASH_DEC_APPLY_COUNT are replaced with
     GC_IS_RECURSIVE, GC_PROTECT_RECURSION, GC_UNPROTECT_RECURSION,
     Z_IS_RECURSIVE, Z_PROTECT_RECURSION, Z_UNPROTECT_RECURSION.

     HASH_FLAG_APPLY_PROTECTION flag and ZEND_HASH_APPLY_PROTECTION() macro
     are removed. All mutable arrays should use recursion protection.
     Corresponding checks should be replaced by Z_REFCOUNTED() or
     !(GC_GLAGS(p) & GC_IMMUTABLE).

```