### PR TITLE
Mising file in pecl distribution

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -53,6 +53,7 @@
    <file name="mustache_zend_closure_lambda.hpp" role="src" />
    <file name="php_mustache.cpp" role="src" />
    <file name="php_mustache.h" role="src" />
+   <file name="php5to7.h" role="src" />
    <file name="tests/MustacheAST____construct.phpt" role="test" />
    <file name="tests/MustacheAST____sleep.phpt" role="test" />
    <file name="tests/MustacheAST__toArray.phpt" role="test" />


### PR DESCRIPTION
Without this file, build / installation from pecl is broken.

```
/dev/shm/BUILD/php-pecl-mustache-0.8.0/NTS/mustache_data.cpp:5:10: fatal error: php5to7.h: No such file or directory
 #include "php5to7.h"
          ^~~~~~~~~~~
compilation terminated.

```