### PR TITLE
Fix build with PHP 7.4

### DIFF
--- a/mustache_data.cpp
+++ b/mustache_data.cpp
@@ -136,7 +136,7 @@ static zend_always_inline void mustache_data_from_array_zval(mustache::Data * no
 {
   HashTable * data_hash = NULL;
   long data_count = 0;
-  ulong key_nindex = 0;
+  zend_ulong key_nindex = 0;
   zend_string * key;
   std::string ckey;
   zval * data_entry = NULL;
@@ -228,7 +228,7 @@ static zend_always_inline void mustache_data_from_double_zval(mustache::Data * n
 static zend_always_inline void mustache_data_from_object_properties_zval(mustache::Data * node, zval * current)
 {
   HashTable * data_hash = NULL;
-  ulong key_nindex = 0;
+  zend_ulong key_nindex = 0;
   zend_string * key;
   std::string ckey;
   zval * data_entry = NULL;
@@ -311,7 +311,7 @@ static zend_always_inline void mustache_data_from_object_properties_zval(mustach
 static zend_always_inline void mustache_data_from_object_functions_zval(mustache::Data * node, zval * current)
 {
   HashTable * data_hash = NULL;
-  ulong key_nindex = 0;
+  zend_ulong key_nindex = 0;
   zend_string * key;
   std::string ckey;
   zval * data_entry = NULL;

--- a/mustache_mustache.cpp
+++ b/mustache_mustache.cpp
@@ -231,7 +231,7 @@ bool mustache_parse_partials_param(zval * array, mustache::Mustache * mustache,
         mustache::Node::Partials * partials)
 {
     HashTable * data_hash = NULL;
-    ulong key_nindex = 0;
+    zend_ulong key_nindex = 0;
 
     // Ignore if not an array
     if( array == NULL || Z_TYPE_P(array) != IS_ARRAY ) {


### PR DESCRIPTION
Build error on FreeBSD with PHP 7.4 RC6:
```
--- mustache_mustache.lo ---
/wrkdirs/usr/ports/devel/pecl-mustache/work-php74/mustache-0.9.0/mustache_mustache.cpp:234:5: error: unknown type name 'ulong'
    ulong key_nindex = 0;
    ^
1 error generated.
*** [mustache_mustache.lo] Error code 1
```
```
--- mustache_data.lo ---
/wrkdirs/usr/ports/devel/pecl-mustache/work-php74/mustache-0.9.0/mustache_data.cpp:139:3: error: unknown type name 'ulong'
  ulong key_nindex = 0;
  ^
/wrkdirs/usr/ports/devel/pecl-mustache/work-php74/mustache-0.9.0/mustache_data.cpp:231:3: error: unknown type name 'ulong'
  ulong key_nindex = 0;
  ^
/wrkdirs/usr/ports/devel/pecl-mustache/work-php74/mustache-0.9.0/mustache_data.cpp:278:32: warning: comparison of address of 'ce->properties_info' not equal to a null pointer is always true [-Wtautological-pointer-compare]
        if( ce != NULL && &ce->properties_info != NULL ) {
                           ~~~~^~~~~~~~~~~~~~~    ~~~~
/wrkdirs/usr/ports/devel/pecl-mustache/work-php74/mustache-0.9.0/mustache_data.cpp:314:3: error: unknown type name 'ulong'
  ulong key_nindex = 0;
  ^
1 warning and 3 errors generated.
*** [mustache_data.lo] Error code 1
```