### PR TITLE
Loading a template from the filesystem with partials resolution: an example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,75 @@ Well, 6000 dollars, after taxes.
 
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
 
+## Examples
+
+You can adapt this Mustache_Template_Loader class or use it as an
+example of how to interface with whatever framework you use. The MustacheAST
+type for example can serialized/unserialized to APCU or other cache.
+
+```
+class Mustache_Template_Loader {
+  public $partials = [];
+  public $partial_pathname_resolver = false;
+  public $mustache_instance = false;
+
+  /**
+   * Loads and renders a template from a path.
+   *
+   * @param string   $tmplpath The input template filesystem path.
+   * @param mixed    $data     The data argument to Mustache::render.
+   * @param callable $callback Resolves a partial name to its filesystem path.
+   *
+   * @return false|string The string output, or false on failure
+   */
+  public static function load_and_render($tmplpath, $data, $callback) {
+    $loader = new Mustache_Template_Loader();
+    $loader->mustache_instance = new \Mustache();
+    $loader->partial_pathname_resolver = $callback;
+    $template_string = file_get_contents($tmplpath);
+    $template_ast = $loader->mustache_instance->parse($template_string);
+    $template_ast_array = $template_ast->toArray();
+    $loader->resolve_partials($template_ast_array);
+    return $loader->mustache_instance->render($template_ast, $data, $loader->partials);
+  }
+
+  public function resolve_partials($ast_array) {
+    if (($ast_array['type'] ?? null) === 512) {
+      // The libmustache src/node.hpp has enum Type TypePartial = 512
+      $partial_name = $ast_array['data'];
+      $partial_ast = $this->partials[$partial_name] ?? null;
+      if ($partial_ast !== null) {
+        // this check prevents the performing of extra work
+        // and by corollary protects against indefinite recursion.
+        return;
+      }
+      $this->partials[$partial_name] = "";
+      $partial_pathname = ($this->partial_pathname_resolver)($partial_name);
+      $partial_string = file_get_contents($partial_pathname);
+      $partial_ast = $this->mustache_instance->parse($partial_string);
+      $this->partials[$partial_name] = $partial_ast;
+      $this->resolve_partials($partial_ast->toArray());
+    } else {
+      // For simplicity the AST node types are ignored here.
+      foreach ($ast_array as $ast_array_value) {
+        if (is_array($ast_array_value)) {
+          $this->resolve_partials($ast_array_value);
+        }
+      }
+    }
+  }
+}
+```
+An example use of this class:
+
+```
+function template_pathname($partial_name) {
+  return '/usr/local/lib/templates/' . $partial_name . '.mustache';
+}
+
+echo Mustache_Template_Loader::load_and_render(
+       template_pathname('topview'),
+       $data,
+       'template_pathname'
+     );
+```


### PR DESCRIPTION
This mustache implementation is fast, well known, stable, and extensively used in some big applications.

Questions such those raised in issues https://github.com/jbboehr/php-mustache/issues/45 and https://github.com/jbboehr/php-mustache/issues/4 suggest that examples of template loading, AST walking, and partials resolution would be helpful. In the spirit of php.net documentation I have just added an examples section to the end of the README.md and provided an example covering all 3 topics.

The Mustache_Template_Loader class is extracted from production code. The implementation of
the resolve_partials function does suggest that it would be nice to expose as constants in the MustacheAST class the type enum from https://github.com/jbboehr/libmustache/blob/master/src/node.hpp

