### PR TITLE
drop zend_exception_get_default usage

### DIFF
--- a/mustache_exceptions.cpp
+++ b/mustache_exceptions.cpp
@@ -18,7 +18,7 @@ zend_class_entry * MustacheParserException_ce_ptr;
 PHP_MINIT_FUNCTION(mustache_exceptions)
 {
   try {
-    zend_class_entry * exception_ce = zend_exception_get_default();
+    zend_class_entry * exception_ce = zend_ce_exception;
 
     // MustacheException
     zend_class_entry mustache_exception_ce;


### PR DESCRIPTION
* `zend_ce_exception` available since 7.0
* `zend_exception_get_default` removed in 8.5