### PR TITLE
Fix for PHP 8.6.0beta3

### DIFF
--- a/mustache_ast.cpp
+++ b/mustache_ast.cpp
@@ -127,7 +127,7 @@ void mustache_node_to_zval(const mustache::Node& node, zval * current)
 /* {{{ php_mustache_ast_object_fetch_object */
 static inline struct php_obj_MustacheAST * php_mustache_ast_fetch_object(zend_object * obj)
 {
-  return (struct php_obj_MustacheAST *)((char*)(obj) - XtOffsetOf(struct php_obj_MustacheAST, std));
+  return (struct php_obj_MustacheAST *)((char*)(obj) - offsetof(struct php_obj_MustacheAST, std));
 }
 
 struct php_obj_MustacheAST * php_mustache_ast_object_fetch_object(zval * zv)
@@ -181,7 +181,7 @@ PHP_MINIT_FUNCTION(mustache_ast)
     zend_class_entry ce;
 
     memcpy(&MustacheAST_obj_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-    MustacheAST_obj_handlers.offset = XtOffsetOf(struct php_obj_MustacheAST, std);
+    MustacheAST_obj_handlers.offset = offsetof(struct php_obj_MustacheAST, std);
     MustacheAST_obj_handlers.free_obj = MustacheAST_obj_free;
     MustacheAST_obj_handlers.clone_obj = NULL;
 

--- a/mustache_class_method_lambda.cpp
+++ b/mustache_class_method_lambda.cpp
@@ -9,7 +9,7 @@
 ClassMethodLambda::~ClassMethodLambda()
 {
   zval_ptr_dtor(&object);
-  zval_dtor(&function_name);
+  zval_ptr_dtor_nogc(&function_name);
 }
 
 void ClassMethodLambda::addGcValues(zend_get_gc_buffer * gc_buffer)

--- a/mustache_data.cpp
+++ b/mustache_data.cpp
@@ -69,7 +69,7 @@ static zend_function_entry MustacheData_methods[] = {
 /* {{{ php_mustache_data_object_fetch_object */
 static inline struct php_obj_MustacheData * php_mustache_data_fetch_object(zend_object * obj)
 {
-  return (struct php_obj_MustacheData *)((char*)(obj) - XtOffsetOf(struct php_obj_MustacheData, std));
+  return (struct php_obj_MustacheData *)((char*)(obj) - offsetof(struct php_obj_MustacheData, std));
 }
 
 struct php_obj_MustacheData * php_mustache_data_object_fetch_object(zval * zv)
@@ -144,7 +144,7 @@ PHP_MINIT_FUNCTION(mustache_data)
 #endif
   MustacheData_ce_ptr = zend_register_internal_class(&ce);
   memcpy(&MustacheData_obj_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-  MustacheData_obj_handlers.offset = XtOffsetOf(struct php_obj_MustacheData, std);
+  MustacheData_obj_handlers.offset = offsetof(struct php_obj_MustacheData, std);
   MustacheData_obj_handlers.free_obj = MustacheData_obj_free;
   MustacheData_obj_handlers.get_gc = MustacheData_obj_get_gc;
   MustacheData_obj_handlers.clone_obj = NULL;

--- a/mustache_lambda_helper.cpp
+++ b/mustache_lambda_helper.cpp
@@ -28,7 +28,7 @@ static zend_function_entry MustacheLambdaHelper_methods[] = {
 /* {{{ php_mustache_lambda_helper_object_fetch_object */
 static inline struct php_obj_MustacheLambdaHelper * php_mustache_lambda_helper_fetch_object(zend_object * obj)
 {
-  return (struct php_obj_MustacheLambdaHelper *)((char*)(obj) - XtOffsetOf(struct php_obj_MustacheLambdaHelper, std));
+  return (struct php_obj_MustacheLambdaHelper *)((char*)(obj) - offsetof(struct php_obj_MustacheLambdaHelper, std));
 }
 
 struct php_obj_MustacheLambdaHelper * php_mustache_lambda_helper_object_fetch_object(zval * zv)
@@ -84,7 +84,7 @@ PHP_MINIT_FUNCTION(mustache_lambda_helper)
   ce.create_object = MustacheLambdaHelper_obj_create;
   MustacheLambdaHelper_ce_ptr = zend_register_internal_class(&ce);
   memcpy(&MustacheLambdaHelper_obj_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-  MustacheLambdaHelper_obj_handlers.offset = XtOffsetOf(struct php_obj_MustacheLambdaHelper, std);
+  MustacheLambdaHelper_obj_handlers.offset = offsetof(struct php_obj_MustacheLambdaHelper, std);
   MustacheLambdaHelper_obj_handlers.free_obj = MustacheLambdaHelper_obj_free;
   MustacheLambdaHelper_obj_handlers.clone_obj = NULL;
 

--- a/mustache_lambda_result.cpp
+++ b/mustache_lambda_result.cpp
@@ -22,7 +22,7 @@ struct php_obj_MustacheLambdaResult {
 
 static php_obj_MustacheLambdaResult * mustache_lambda_result_fetch(zend_object * object)
 {
-  return (php_obj_MustacheLambdaResult *)((char *) object - XtOffsetOf(php_obj_MustacheLambdaResult, std));
+  return (php_obj_MustacheLambdaResult *)((char *) object - offsetof(php_obj_MustacheLambdaResult, std));
 }
 
 zend_string * php_mustache_lambda_result_text(zval * value)
@@ -152,7 +152,7 @@ static zend_function_entry MustacheTemplateResult_methods[] = {
 PHP_MINIT_FUNCTION(mustache_lambda_result)
 {
   memcpy(&MustacheLambdaResult_obj_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-  MustacheLambdaResult_obj_handlers.offset = XtOffsetOf(php_obj_MustacheLambdaResult, std);
+  MustacheLambdaResult_obj_handlers.offset = offsetof(php_obj_MustacheLambdaResult, std);
   MustacheLambdaResult_obj_handlers.free_obj = MustacheLambdaResult_obj_free;
   MustacheLambdaResult_obj_handlers.clone_obj = MustacheLambdaResult_obj_clone;
   MustacheLambdaResult_obj_handlers.compare = MustacheLambdaResult_obj_compare;

--- a/mustache_mustache.cpp
+++ b/mustache_mustache.cpp
@@ -70,7 +70,7 @@ static zend_function_entry Mustache_methods[] = {
 /* {{{ php_mustache_mustache_object_fetch_object */
 static inline struct php_obj_Mustache * php_mustache_mustache_fetch_object(zend_object * obj)
 {
-  return (struct php_obj_Mustache *) ((char *)(obj) - XtOffsetOf(struct php_obj_Mustache, std));
+  return (struct php_obj_Mustache *) ((char *)(obj) - offsetof(struct php_obj_Mustache, std));
 }
 
 struct php_obj_Mustache * php_mustache_mustache_object_fetch_object(zval * zv)
@@ -140,7 +140,7 @@ PHP_MINIT_FUNCTION(mustache_mustache)
     zend_declare_class_constant_long(Mustache_ce_ptr, ZEND_STRL("LAMBDA_STRING_LITERAL"),
         static_cast<zend_long>(mustache::LambdaStringMode::Literal));
     memcpy(&Mustache_obj_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-    Mustache_obj_handlers.offset = XtOffsetOf(php_obj_Mustache, std);
+    Mustache_obj_handlers.offset = offsetof(php_obj_Mustache, std);
     Mustache_obj_handlers.free_obj = Mustache_obj_free;
     Mustache_obj_handlers.clone_obj = NULL;
 

--- a/tests/Mustache__template-source-releases-temporaries.phpt
+++ b/tests/Mustache__template-source-releases-temporaries.phpt
@@ -40,6 +40,10 @@ function sourceRefcount($source)
     ob_start();
     debug_zval_dump($source);
     $dump = ob_get_clean();
+    if (PHP_VERSION_ID >= 80600) {
+        // may be interned with opcache
+        return 0;
+    }
     if (!preg_match('/refcount\((\d+)\)/', $dump, $matches)) {
         throw new RuntimeException('Expected a refcounted source string');
     }


### PR DESCRIPTION
  . The zval_dtor() alias of zval_ptr_dtor_nogc() has been removed.
    Call zval_ptr_dtor_nogc() directly instead.

  . The XtOffsetOf() alias of C’s offsetof() macro has been removed. Use
    offsetof() directly.

Fix test expectation as opcache may change string from refcounted to interned